### PR TITLE
fixed typo README, added more tests for Bases and resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ On Windows
 
 ## Development
 
-Set environment variable `OPENBW_MPQ_PATH` to point to location of Starcraft, or folder where Starcraft files `StarDat.mpq`, `BrooDat.mpq`, `Patch_rt.mpq` is located.
+Set environment variable `OPENBW_MPQ_PATH` to point to location of Starcraft, or folder where Starcraft files `StarDat.mpq`, `BrooDat.mpq`, `Patch_rt.mpq` are located.
 
 ### Using command line
 

--- a/Tests/MapBasesInfo.cpp
+++ b/Tests/MapBasesInfo.cpp
@@ -1,0 +1,115 @@
+#include "bwem.h"
+#include "mapImpl.h"
+#include "BWAPI/GameImpl.h"
+#include "BW/BWData.h"
+
+#include "gtest/gtest.h"
+
+TEST(MapBasesInfo, MapFindBasesForStartingLocations) {
+	BWEM::detail::MapImpl map;
+
+	BW::GameOwner gameOwner;
+
+	gameOwner.setPrintTextCallback([](const char* str) {
+		std::string s;
+		while (*str) {
+			char c = *str++;
+			if (static_cast<unsigned>(c) >= 0x20 || c == 9 || c == 10 || c == 13) s += c;
+		}
+		printf("%s\n", s.c_str());
+	});
+
+	BWAPI::BroodwarImpl_handle h(gameOwner.getGame());
+	h->setCharacterName("bwapi");
+	h->setGameType(BWAPI::GameTypes::Melee);
+	BWAPI::BroodwarImpl.bwgame.setMapFileName("data\\maps\\(2)Showdown.scx");
+	h->createSinglePlayerGame([&h]()
+	{
+		if (!h->self())
+		{
+			auto firstPlayer = h->getPlayer(0);
+			h->switchToPlayer(firstPlayer);
+		}
+		else
+		{
+			auto self = h->self();
+			self->setRace(BWAPI::Races::Terran);
+			h->startGame();
+		}
+	});
+	map.Initialize(&(*h));
+	EXPECT_EQ(true, map.FindBasesForStartingLocations());
+}
+
+TEST(MapBasesInfo, MapStartLocationCount2PlayersMap) {
+	BWEM::detail::MapImpl map;
+
+	BW::GameOwner gameOwner;
+
+	gameOwner.setPrintTextCallback([](const char* str) {
+		std::string s;
+		while (*str) {
+			char c = *str++;
+			if (static_cast<unsigned>(c) >= 0x20 || c == 9 || c == 10 || c == 13) s += c;
+		}
+		printf("%s\n", s.c_str());
+	});
+
+	BWAPI::BroodwarImpl_handle h(gameOwner.getGame());
+	h->setCharacterName("bwapi");
+	h->setGameType(BWAPI::GameTypes::Melee);
+	BWAPI::BroodwarImpl.bwgame.setMapFileName("data\\maps\\(2)Showdown.scx");
+	h->createSinglePlayerGame([&h]()
+	{
+		if (!h->self())
+		{
+			auto firstPlayer = h->getPlayer(0);
+			h->switchToPlayer(firstPlayer);
+		}
+		else
+		{
+			auto self = h->self();
+			self->setRace(BWAPI::Races::Terran);
+			h->startGame();
+		}
+	});
+	map.Initialize(&(*h));
+	map.FindBasesForStartingLocations();
+	EXPECT_EQ(2, map.StartingLocations().size());
+}
+
+TEST(MapBasesInfo, MapBaseCount) {
+	BWEM::detail::MapImpl map;
+
+	BW::GameOwner gameOwner;
+
+	gameOwner.setPrintTextCallback([](const char* str) {
+		std::string s;
+		while (*str) {
+			char c = *str++;
+			if (static_cast<unsigned>(c) >= 0x20 || c == 9 || c == 10 || c == 13) s += c;
+		}
+		printf("%s\n", s.c_str());
+	});
+
+	BWAPI::BroodwarImpl_handle h(gameOwner.getGame());
+	h->setCharacterName("bwapi");
+	h->setGameType(BWAPI::GameTypes::Melee);
+	BWAPI::BroodwarImpl.bwgame.setMapFileName("data\\maps\\(2)Showdown.scx");
+	h->createSinglePlayerGame([&h]()
+	{
+		if (!h->self())
+		{
+			auto firstPlayer = h->getPlayer(0);
+			h->switchToPlayer(firstPlayer);
+		}
+		else
+		{
+			auto self = h->self();
+			self->setRace(BWAPI::Races::Terran);
+			h->startGame();
+		}
+	});
+	map.Initialize(&(*h));
+	EXPECT_EQ(8, map.BaseCount());
+}

--- a/Tests/MapResourcesInfo.cpp
+++ b/Tests/MapResourcesInfo.cpp
@@ -1,27 +1,11 @@
 #include "bwem.h"
 #include "mapImpl.h"
-#include "DummyBWAPIMap.h"
 #include "BWAPI/GameImpl.h"
 #include "BW/BWData.h"
 
 #include "gtest/gtest.h"
 
-TEST(MapInitialization, MapInitiallyNotInitialized) {
-	BWEM::detail::MapImpl map;
-
-	EXPECT_EQ(false, map.Initialized());
-}
-
-TEST(MapInitialization, MapInitialized) {
-	BWEM::detail::MapImpl map;
-
-	DummyBWAPIMap dummyMap;
-
-	map.Initialize(&dummyMap);
-	EXPECT_EQ(true, map.Initialized());
-}
-
-TEST(MapInitialization, MapInitializedUsingOpenBW) {
+TEST(MapResourcesInfo, MapGeyserCount) {
 	BWEM::detail::MapImpl map;
 
 	BW::GameOwner gameOwner;
@@ -54,5 +38,41 @@ TEST(MapInitialization, MapInitializedUsingOpenBW) {
 		}
 	});
 	map.Initialize(&(*h));
-	EXPECT_EQ(true, map.Initialized());
+	EXPECT_EQ(6, map.Geysers().size());
+}
+
+TEST(MapResourcesInfo, MapMineralCount) {
+	BWEM::detail::MapImpl map;
+
+	BW::GameOwner gameOwner;
+
+	gameOwner.setPrintTextCallback([](const char* str) {
+		std::string s;
+		while (*str) {
+			char c = *str++;
+			if (static_cast<unsigned>(c) >= 0x20 || c == 9 || c == 10 || c == 13) s += c;
+		}
+		printf("%s\n", s.c_str());
+	});
+
+	BWAPI::BroodwarImpl_handle h(gameOwner.getGame());
+	h->setCharacterName("bwapi");
+	h->setGameType(BWAPI::GameTypes::Melee);
+	BWAPI::BroodwarImpl.bwgame.setMapFileName("data\\maps\\(2)Showdown.scx");
+	h->createSinglePlayerGame([&h]()
+	{
+		if (!h->self())
+		{
+			auto firstPlayer = h->getPlayer(0);
+			h->switchToPlayer(firstPlayer);
+		}
+		else
+		{
+			auto self = h->self();
+			self->setRace(BWAPI::Races::Terran);
+			h->startGame();
+		}
+	});
+	map.Initialize(&(*h));
+	EXPECT_EQ(46, map.Minerals().size());
 }

--- a/Tests/Tests.vcxproj
+++ b/Tests/Tests.vcxproj
@@ -105,7 +105,9 @@
     <ClCompile Include="..\external\openbw-bwapi\bwapi\Shared\RegionShared.cpp" />
     <ClCompile Include="..\external\openbw-bwapi\bwapi\Shared\UnitShared.cpp" />
     <ClCompile Include="..\external\openbw-bwapi\bwapi\Util\Source\Util\Sha1.cpp" />
+    <ClCompile Include="MapBasesInfo.cpp" />
     <ClCompile Include="MapInitialization.cpp" />
+    <ClCompile Include="MapResourcesInfo.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\BWEM\BWEM.vcxproj">

--- a/Tests/Tests.vcxproj.filters
+++ b/Tests/Tests.vcxproj.filters
@@ -245,6 +245,12 @@
     <ClCompile Include="..\external\openbw-bwapi\bwapi\BWAPI\Source\BW\UnitTarget.cpp">
       <Filter>BWAPIObj</Filter>
     </ClCompile>
+    <ClCompile Include="MapBasesInfo.cpp">
+      <Filter>Tests</Filter>
+    </ClCompile>
+    <ClCompile Include="MapResourcesInfo.cpp">
+      <Filter>Tests</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <None Include="data\maps\(2)Showdown.scx">


### PR DESCRIPTION
Added more tests for:

* Correct execution of `FindBasesForStartingLocations()`.
* Total number of `Bases` in the map.
* Number of `Starting Locations` in the map.
* Number of `Mineral` patches.
* Number of `Geysers`.

All of this tests except the `FindBasesForStartingLocations()` fail, It always return `0` for the other tests,
