### PR TITLE
Fix map printer and add example project

### DIFF
--- a/BWEM/include/mapDrawer.h
+++ b/BWEM/include/mapDrawer.h
@@ -12,7 +12,6 @@
 
 #include <BWAPI.h>
 
-class BMP;
 namespace BWEM {
 class Map;
 namespace utils {

--- a/examples/ExampleAIModule/ExampleAIModule.vcxproj
+++ b/examples/ExampleAIModule/ExampleAIModule.vcxproj
@@ -1,0 +1,107 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{2E63AE74-758A-4607-9DE4-D28E814A6E13}</ProjectGuid>
+    <RootNamespace>ExampleAIModule</RootNamespace>
+    <Keyword>Win32Proj</Keyword>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <PlatformToolset>v141</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <CharacterSet>Unicode</CharacterSet>
+    <PlatformToolset>v141</PlatformToolset>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup>
+    <_ProjectFileVersion>10.0.30319.1</_ProjectFileVersion>
+    <LinkIncremental Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">false</LinkIncremental>
+    <LinkIncremental Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">false</LinkIncremental>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <Optimization>Disabled</Optimization>
+      <AdditionalIncludeDirectories>../include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>NOMINMAX;WIN32;_DEBUG;_WINDOWS;_USRDLL;EXAMPLEAIMODULE_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <MinimalRebuild>false</MinimalRebuild>
+      <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
+      <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
+    </ClCompile>
+    <PreLinkEvent />
+    <Link>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <SubSystem>Windows</SubSystem>
+      <ImportLibrary>$(IntDir)$(TargetName).lib</ImportLibrary>
+      <TargetMachine>MachineX86</TargetMachine>
+      <AdditionalDependencies>../lib/BWAPId.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <Optimization>MaxSpeed</Optimization>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <AdditionalIncludeDirectories>../include;$(BWAPI_DIR)/420/include;../../BWEM/include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>NOMINMAX;WIN32;NDEBUG;_WINDOWS;_USRDLL;EXAMPLEAIMODULE_EXPORTS;BWEM_USE_MAP_PRINTER;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <LanguageStandard>stdcpp17</LanguageStandard>
+    </ClCompile>
+    <PreLinkEvent />
+    <Link>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <SubSystem>Windows</SubSystem>
+      <OptimizeReferences>true</OptimizeReferences>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <ImportLibrary>$(IntDir)$(TargetName).lib</ImportLibrary>
+      <TargetMachine>MachineX86</TargetMachine>
+      <AdditionalDependencies>$(BWAPI_DIR)/420/lib/BWAPI.lib;../../lib/BWEM-Release.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClCompile Include="..\examples.cpp" />
+    <ClCompile Include="..\exampleWall.cpp" />
+    <ClCompile Include="Source\Dll.cpp" />
+    <ClCompile Include="Source\ExampleAIModule.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\examples.h" />
+    <ClInclude Include="..\exampleWall.h" />
+    <ClInclude Include="Source\ExampleAIModule.h" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/examples/ExampleAIModule/Source/Dll.cpp
+++ b/examples/ExampleAIModule/Source/Dll.cpp
@@ -1,0 +1,22 @@
+#include <BWAPI.h>
+#include <Windows.h>
+
+#include "ExampleAIModule.h"
+
+extern "C" __declspec(dllexport) void gameInit(BWAPI::Game* game) { BWAPI::BroodwarPtr = game; }
+BOOL APIENTRY DllMain( HANDLE hModule, DWORD ul_reason_for_call, LPVOID lpReserved )
+{
+  switch (ul_reason_for_call)
+  {
+  case DLL_PROCESS_ATTACH:
+    break;
+  case DLL_PROCESS_DETACH:
+    break;
+  }
+  return TRUE;
+}
+
+extern "C" __declspec(dllexport) BWAPI::AIModule* newAIModule()
+{
+  return new ExampleAIModule();
+}

--- a/examples/ExampleAIModule/Source/ExampleAIModule.cpp
+++ b/examples/ExampleAIModule/Source/ExampleAIModule.cpp
@@ -1,0 +1,132 @@
+#include "ExampleAIModule.h"
+
+#include <cassert>
+#include <iostream>
+
+#include <bwem.h>
+#include <mapPrinter.h>
+
+#include "../../examples.h"
+
+using namespace BWAPI;
+using namespace Filter;
+
+void ExampleAIModule::onStart()
+{
+  // Print the map name.
+  // BWAPI returns std::string when retrieving a string, don't forget to add .c_str() when printing!
+  Broodwar << "The map is " << Broodwar->mapName() << "!" << std::endl;
+
+  // Enable the UserInput flag, which allows us to control the bot and type messages.
+  Broodwar->enableFlag(Flag::UserInput);
+
+  // Uncomment the following line and the bot will know about everything through the fog of war (cheat).
+  //Broodwar->enableFlag(Flag::CompleteMapInformation);
+
+  // Set the command optimization level so that common commands can be grouped
+  // and reduce the bot's APM (Actions Per Minute).
+  Broodwar->setCommandOptimizationLevel(2);
+
+  try {
+	  // Enable the UserInput flag, which allows us to control the bot and type messages.
+	  Broodwar->enableFlag(Flag::UserInput);
+
+	  // Uncomment the following line and the bot will know about everything through the fog of war (cheat).
+	  //Broodwar->enableFlag(Flag::CompleteMapInformation);
+
+	  // Set the command optimization level so that common commands can be grouped
+	  // and reduce the bot's APM (Actions Per Minute).
+	  Broodwar->setCommandOptimizationLevel(2);
+
+	  // Initialize BWEM.
+	  BWEM::Map::Instance().Initialize(BroodwarPtr);
+	  BWEM::Map::Instance().EnableAutomaticPathAnalysis();
+	  bool startingLocationsOK = BWEM::Map::Instance().FindBasesForStartingLocations();
+	  assert(startingLocationsOK);
+	  BWEM::utils::MapPrinter::Initialize(&(BWEM::Map::Instance()));
+	  BWEM::utils::printMap(BWEM::Map::Instance()); // will print the map into the file <StarCraftFolder>bwapi-data/map.bmp
+	  BWEM::utils::pathExample(BWEM::Map::Instance()); // add to the printed map a path between two starting locations
+  }
+  catch (const std::exception &e) {
+	  Broodwar << "EXCEPTION: " << e.what() << std::endl;
+  }
+}
+
+void ExampleAIModule::onEnd(bool isWinner)
+{
+}
+
+void ExampleAIModule::onFrame()
+{
+	try {
+		BWEM::utils::gridMapExample(BWEM::Map::Instance(), BWAPI::Broodwar);
+		BWEM::utils::drawMap(BWEM::Map::Instance(), BWAPI::BroodwarPtr);
+	}
+	catch (const std::exception & e) {
+		Broodwar << "EXCEPTION: " << e.what() << std::endl;
+	}
+}
+
+void ExampleAIModule::onSendText(std::string text)
+{
+	Broodwar->sendText("%s", text.c_str());
+}
+
+void ExampleAIModule::onReceiveText(BWAPI::Player player, std::string text)
+{
+}
+
+void ExampleAIModule::onPlayerLeft(BWAPI::Player player)
+{
+}
+
+void ExampleAIModule::onNukeDetect(BWAPI::Position target)
+{
+}
+
+void ExampleAIModule::onUnitDiscover(BWAPI::Unit unit)
+{
+}
+
+void ExampleAIModule::onUnitEvade(BWAPI::Unit unit)
+{
+}
+
+void ExampleAIModule::onUnitShow(BWAPI::Unit unit)
+{
+}
+
+void ExampleAIModule::onUnitHide(BWAPI::Unit unit)
+{
+}
+
+void ExampleAIModule::onUnitCreate(BWAPI::Unit unit)
+{
+}
+
+void ExampleAIModule::onUnitDestroy(BWAPI::Unit unit)
+{
+	try {
+		if (unit->getType().isMineralField()) BWEM::Map::Instance().OnMineralDestroyed(unit);
+		else if (unit->getType().isSpecialBuilding()) BWEM::Map::Instance().OnStaticBuildingDestroyed(unit);
+	}
+	catch (const std::exception & e) {
+		Broodwar << "EXCEPTION: " << e.what() << std::endl;
+	}
+}
+
+void ExampleAIModule::onUnitMorph(BWAPI::Unit unit)
+{
+}
+
+void ExampleAIModule::onUnitRenegade(BWAPI::Unit unit)
+{
+}
+
+void ExampleAIModule::onSaveGame(std::string gameName)
+{
+}
+
+void ExampleAIModule::onUnitComplete(BWAPI::Unit unit)
+{
+}

--- a/examples/ExampleAIModule/Source/ExampleAIModule.h
+++ b/examples/ExampleAIModule/Source/ExampleAIModule.h
@@ -1,0 +1,29 @@
+#pragma once
+#include <BWAPI.h>
+
+// Remember not to use "Broodwar" in any global class constructor!
+
+class ExampleAIModule : public BWAPI::AIModule
+{
+public:
+  // Virtual functions for callbacks, leave these as they are.
+  virtual void onStart();
+  virtual void onEnd(bool isWinner);
+  virtual void onFrame();
+  virtual void onSendText(std::string text);
+  virtual void onReceiveText(BWAPI::Player player, std::string text);
+  virtual void onPlayerLeft(BWAPI::Player player);
+  virtual void onNukeDetect(BWAPI::Position target);
+  virtual void onUnitDiscover(BWAPI::Unit unit);
+  virtual void onUnitEvade(BWAPI::Unit unit);
+  virtual void onUnitShow(BWAPI::Unit unit);
+  virtual void onUnitHide(BWAPI::Unit unit);
+  virtual void onUnitCreate(BWAPI::Unit unit);
+  virtual void onUnitDestroy(BWAPI::Unit unit);
+  virtual void onUnitMorph(BWAPI::Unit unit);
+  virtual void onUnitRenegade(BWAPI::Unit unit);
+  virtual void onSaveGame(std::string gameName);
+  virtual void onUnitComplete(BWAPI::Unit unit);
+  // Everything below this line is safe to modify.
+
+};

--- a/examples/examples.cpp
+++ b/examples/examples.cpp
@@ -108,13 +108,13 @@ void drawMap(const Map & theMap, BWAPI::Game *game)
 
 static void printNeutral(const Map & theMap, const Neutral * n, MapPrinter::Color col)
 {
-	const WalkPosition delta(n->Pos().x < theMap.Center().x ? +1 : -1, n->Pos().y < theMap.Center().y ? +1 : -1);
+	const BWAPI::WalkPosition delta(n->Pos().x < theMap.Center().x ? +1 : -1, n->Pos().y < theMap.Center().y ? +1 : -1);
 	const int stackSize = MapPrinter::showStackedNeutrals ? theMap.GetTile(n->TopLeft()).StackedNeutrals() : 1;
 
 	for (int i = 0 ; i < stackSize ; ++i)
 	{
-		auto origin = WalkPosition(n->TopLeft()) + delta * i;
-		auto size = WalkPosition (n->Size());
+		auto origin = BWAPI::WalkPosition(n->TopLeft()) + delta * i;
+		auto size = BWAPI::WalkPosition (n->Size());
 		if (!theMap.Valid(origin) || !theMap.Valid(origin + size - 1)) break;
 
 		MapPrinter::Get().Rectangle(origin, origin + size - 1, col, MapPrinter::fill);
@@ -124,8 +124,8 @@ static void printNeutral(const Map & theMap, const Neutral * n, MapPrinter::Colo
 			{
 				MapPrinter::Get().Point(origin, MapPrinter::Color::blockingNeutrals);
 				MapPrinter::Get().Point(origin + size - 1, MapPrinter::Color::blockingNeutrals);
-				MapPrinter::Get().Point(WalkPosition(origin.x, (origin + size - 1).y), MapPrinter::Color::blockingNeutrals);
-				MapPrinter::Get().Point(WalkPosition((origin + size - 1).x, origin.y), MapPrinter::Color::blockingNeutrals);
+				MapPrinter::Get().Point(BWAPI::WalkPosition(origin.x, (origin + size - 1).y), MapPrinter::Color::blockingNeutrals);
+				MapPrinter::Get().Point(BWAPI::WalkPosition((origin + size - 1).x, origin.y), MapPrinter::Color::blockingNeutrals);
 			}
 			else
 				MapPrinter::Get().Rectangle(origin, origin + size - 1, MapPrinter::Color::blockingNeutrals);
@@ -133,7 +133,7 @@ static void printNeutral(const Map & theMap, const Neutral * n, MapPrinter::Colo
 }
 
 
-static MapPrinter::Color getZoneColor(const Area * area, map<int, MapPrinter::Color> & map_Zone_Color)
+static MapPrinter::Color getZoneColor(const Area * area, std::map<int, MapPrinter::Color> & map_Zone_Color)
 {
 	const int zoneId = MapPrinter::showAreas ? area->Id() : area->GroupId();
 	auto it = map_Zone_Color.emplace(zoneId, MapPrinter::Color());
@@ -154,7 +154,7 @@ static MapPrinter::Color getZoneColor(const Area * area, map<int, MapPrinter::Co
 				// 2) color should differ enough from the colors of the neighbouring Areas
 				 (	MapPrinter::showAreas &&
 					any_of(area->ChokePointsByArea().begin(), area->ChokePointsByArea().end(),
-						[&map_Zone_Color, &color](const pair<const Area *, const std::vector<ChokePoint> *> & neighbour)
+						[&map_Zone_Color, &color](const std::pair<const Area *, const std::vector<ChokePoint> *> & neighbour)
 						{
 							auto it2 = map_Zone_Color.find(neighbour.first->Id());
 							if (it2 == map_Zone_Color.end()) return false;
@@ -171,12 +171,12 @@ static MapPrinter::Color getZoneColor(const Area * area, map<int, MapPrinter::Co
 
 void printMap(const Map & theMap)
 {
-	map<int, MapPrinter::Color> map_Zone_Color;		// a "Zone" is either an Area or a continent
+	std::map<int, MapPrinter::Color> map_Zone_Color;		// a "Zone" is either an Area or a continent
 
 	for (int y = 0 ; y < theMap.WalkSize().y ; ++y)
 	for (int x = 0 ; x < theMap.WalkSize().x ; ++x)
 	{
-		WalkPosition p(x, y);
+		BWAPI::WalkPosition p(x, y);
 		const auto & miniTile = theMap.GetMiniTile(p, check_t::no_check);
 
 		MapPrinter::Color col;
@@ -218,19 +218,19 @@ void printMap(const Map & theMap)
 		for (int y = 0 ; y < theMap.Size().y ; ++y)
 		for (int x = 0 ; x < theMap.Size().x ; ++x)
 		{
-			int data = theMap.GetTile(TilePosition(x, y)).Data();
+			int data = theMap.GetTile(BWAPI::TilePosition(x, y)).Data();
 			uint8_t c = uint8_t(((data/1)*1) % 256);
 			MapPrinter::Color col(c, c, c);
-			WalkPosition origin(TilePosition(x, y));
+			BWAPI::WalkPosition origin(BWAPI::TilePosition(x, y));
 			MapPrinter::Get().Rectangle(origin, origin + 3, col, MapPrinter::fill);
 		}
 
 	if (MapPrinter::showUnbuildable)
 		for (int y = 0 ; y < theMap.Size().y ; ++y)
 		for (int x = 0 ; x < theMap.Size().x ; ++x)
-			if (!theMap.GetTile(TilePosition(x, y)).Buildable())
+			if (!theMap.GetTile(BWAPI::TilePosition(x, y)).Buildable())
 			{
-				WalkPosition origin(TilePosition(x, y));
+				BWAPI::WalkPosition origin(BWAPI::TilePosition(x, y));
 				MapPrinter::Get().Rectangle(origin+1, origin + 2, MapPrinter::Color::unbuildable);
 			}
 
@@ -238,12 +238,12 @@ void printMap(const Map & theMap)
 		for (int y = 0 ; y < theMap.Size().y ; ++y)
 		for (int x = 0 ; x < theMap.Size().x ; ++x)
 		{
-			int groundHeight = theMap.GetTile(TilePosition(x, y)).GroundHeight();
+			int groundHeight = theMap.GetTile(BWAPI::TilePosition(x, y)).GroundHeight();
 			if (groundHeight >= 1)
 				for (int dy = 0 ; dy < 4 ; ++dy)
 				for (int dx = 0 ; dx < 4 ; ++dx)
 				{
-					WalkPosition p = WalkPosition(TilePosition(x, y)) + WalkPosition(dx, dy);
+					BWAPI::WalkPosition p = BWAPI::WalkPosition(BWAPI::TilePosition(x, y)) + BWAPI::WalkPosition(dx, dy);
 					if (theMap.GetMiniTile(p, check_t::no_check).Walkable())		// groundHeight is usefull only for walkable miniTiles
 						if ((dx + dy) & (groundHeight == 1 ? 1 : 3))
 							MapPrinter::Get().Point(p, MapPrinter::Color::higherGround);
@@ -258,9 +258,9 @@ void printMap(const Map & theMap)
 			for (const Base & base : area.Bases())
 			{
 				for (const Mineral * m : base.Minerals())
-					MapPrinter::Get().Line(WalkPosition(base.Center()), WalkPosition(m->Pos()), MapPrinter::Color::bases);
+					MapPrinter::Get().Line(BWAPI::WalkPosition(base.Center()), BWAPI::WalkPosition(m->Pos()), MapPrinter::Color::bases);
 				for (const Geyser * g : base.Geysers())
-					MapPrinter::Get().Line(WalkPosition(base.Center()), WalkPosition(g->Pos()), MapPrinter::Color::bases);
+					MapPrinter::Get().Line(BWAPI::WalkPosition(base.Center()), BWAPI::WalkPosition(g->Pos()), MapPrinter::Color::bases);
 			}
 
 	if (MapPrinter::showGeysers)
@@ -276,10 +276,10 @@ void printMap(const Map & theMap)
 			printNeutral(theMap, s.get(), MapPrinter::Color::staticBuildings);
 
 	if (MapPrinter::showStartingLocations)
-		for (TilePosition t : theMap.StartingLocations())
+		for (BWAPI::TilePosition t : theMap.StartingLocations())
 		{
-			WalkPosition origin(t);
-			WalkPosition size(UnitType(Terran_Command_Center).tileSize());	// same size for other races
+			BWAPI::WalkPosition origin(t);
+			BWAPI::WalkPosition size(BWAPI::UnitType(BWAPI::UnitTypes::Terran_Command_Center).tileSize());	// same size for other races
 			MapPrinter::Get().Rectangle(origin, origin + size - 1, MapPrinter::Color::startingLocations, MapPrinter::fill);
 		}
 
@@ -288,8 +288,8 @@ void printMap(const Map & theMap)
 		{
 			for (const Base & base : area.Bases())
 			{
-				WalkPosition origin(base.Location());
-				WalkPosition size(UnitType(Terran_Command_Center).tileSize());	// same size for other races
+				BWAPI::WalkPosition origin(base.Location());
+				BWAPI::WalkPosition size(BWAPI::UnitType(BWAPI::UnitTypes::Terran_Command_Center).tileSize());	// same size for other races
 				auto dashMode = base.BlockingMinerals().empty() ? MapPrinter::not_dashed : MapPrinter::dashed;
 				MapPrinter::Get().Rectangle(origin, origin + size - 1, MapPrinter::Color::bases, MapPrinter::do_not_fill, dashMode);
 			}
@@ -333,10 +333,10 @@ void pathExample(const Map & theMap)
 
 	const MapPrinter::Color col(255, 255, 255);
 
-	WalkPosition a = WalkPosition(random_element(theMap.StartingLocations()));
+	BWAPI::WalkPosition a = BWAPI::WalkPosition(random_element(theMap.StartingLocations()));
 	
-	WalkPosition b = a;
-	while (b == a) b = WalkPosition(random_element(theMap.StartingLocations()));
+	BWAPI::WalkPosition b = a;
+	while (b == a) b = BWAPI::WalkPosition(random_element(theMap.StartingLocations()));
 
 //	Uncomment this to use random positions for a and b:
 //	a = WalkPosition(theMap.RandomPosition());
@@ -346,7 +346,7 @@ void pathExample(const Map & theMap)
 	MapPrinter::Get().Circle(b, 6, col, MapPrinter::fill);
 
 	int length;
-	const CPPath & Path = theMap.GetPath(Position(a), Position(b), &length);
+	const CPPath & Path = theMap.GetPath(BWAPI::Position(a), BWAPI::Position(b), &length);
 
 	if (length < 0) return;		// cannot reach b from a
 


### PR DESCRIPTION
With the initial removal of the EasyBMP dependency, the map printer had no way to generate image files. This PR re-enables map printing support with a private nested class stitched together from [MIG](https://github.com/adakitesystems/mig) for image writing.

An example project has also been added to demonstrate BWEM's map and map printer initialization.

**Note:** MIG (EasyBMP's replacement) depends on `stb_image_write.h` which is **NOT** included in this PR. Users must obtain this dependency themselves or it could be added as a submodule?

Fighting Spirit example printout:
![map](https://user-images.githubusercontent.com/22711643/40735524-9ae30db0-63f8-11e8-9af2-4c1caf60e93c.png)