### PR TITLE
Fix Cmake for tests on some platforms

### DIFF
--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -18,7 +18,7 @@ add_library(googletest
 
 file(GLOB testsources
 	#${GOOGLETEST_SOURCES}
-  ${PROJECT_SOURCE_DIR}/tests/*.cpp
+  ${PROJECT_SOURCE_DIR}/Tests/*.cpp
 )
 
 include_directories(
@@ -46,6 +46,7 @@ target_link_libraries(tests
   googletest
   BWEBlib
   BWAPILIB
+  dl
 )
 
 include(CTest)


### PR DESCRIPTION
There is a typo in the Glob that trips cmake on some platforms. Also, dl is required by GoogleTests, but wasn't explicitly linked.